### PR TITLE
Fix forex items values

### DIFF
--- a/lib/candlesticks/src/widgets/mobile_chart.dart
+++ b/lib/candlesticks/src/widgets/mobile_chart.dart
@@ -6,7 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import '../../../Services/bets_service.dart';
+import '../../../services/bets_service.dart';
 import '../../../helpers/common.dart';
 import '../../../helpers/range_painter.dart';
 import '../../../models/rectangle_zone.dart';

--- a/lib/candlesticks/src/widgets/mobile_chart.dart
+++ b/lib/candlesticks/src/widgets/mobile_chart.dart
@@ -604,7 +604,7 @@ class MobileChartState extends State<MobileChart> with WidgetsBindingObserver {
                                     high: tweenEnd,
                                     width: priceBarWidth,
                                     paintCurrency: (
-                                        widget.ticker.contains('/')
+                                        Common().isTickerForex(widget.ticker)
                                             ? 0
                                             : (_dollarCurrency ? 2 : 1) ),
                                     chartHeight: chartHeight,

--- a/lib/helpers/common.dart
+++ b/lib/helpers/common.dart
@@ -34,10 +34,8 @@ import 'package:image_cropper/image_cropper.dart';
 
 class Common {
 
-  bool isTickerForex(String ticker){
-
-    List<String> forexTickers = 
-    [ 
+  bool isTickerForex(String ticker) {
+    List<String> forexTickers = [
       "EUR/USD",
       "USD/JPY",
       "GPB/USD",
@@ -46,7 +44,7 @@ class Common {
       "XRP/BTC",
       "AUD/USD",
       "USD/CHF",
-      "BTC/ETH" 
+      "BTC/ETH"
     ];
 
     return forexTickers.contains(ticker);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,7 +13,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'firebase_options.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:betrader/Services/bets_service.dart';
+import 'package:betrader/services/bets_service.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/services.dart';

--- a/lib/services/bets_service.dart
+++ b/lib/services/bets_service.dart
@@ -10,7 +10,6 @@ import '../models/trends.dart';
 class BetsService {
   final FlutterSecureStorage _storage = const FlutterSecureStorage();
 
-
   Future<Bet?> fetchBet(String betId, String currency) async {
     String? userId = await _storage.read(key: "sessionToken");
     final response = await Common().postRequestWrapper(
@@ -234,14 +233,17 @@ class BetsService {
   }
 
   Future<List<Candle>> fetchCandles(String symbol, int hoursTimeframe, String currency) async {
+    // Para items de tipo Forex, siempre usar EUR independientemente de la currency del usuario
+    final finalCurrency = Common().isTickerForex(symbol) ? 'EUR' : currency;
+    
     final response = await Common().postRequestWrapper(
       'FinancialAssets',
       'FetchCandles',
       {
         'id': symbol,
         'timeframe': hoursTimeframe,
-        // currency -> 'EUR' / 'USD'
-        'currency': currency
+        // currency: 'EUR' para Forex, 'EUR'/'USD' para otros según preferencia del usuario
+        'currency': finalCurrency
       },
     );
 

--- a/lib/ui/awards_page.dart
+++ b/lib/ui/awards_page.dart
@@ -15,7 +15,7 @@ import 'package:google_fonts/google_fonts.dart' hide Config;
 import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tutorial_coach_mark/tutorial_coach_mark.dart';
-import '../Services/bets_service.dart';
+import '../services/bets_service.dart';
 import '../config/config.dart';
 import '../helpers/common.dart';
 import '../helpers/slider.dart';

--- a/lib/ui/bets_page.dart
+++ b/lib/ui/bets_page.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:ui';
-import 'package:betrader/Services/bets_service.dart';
+import 'package:betrader/services/bets_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';

--- a/lib/ui/exact_price_view.dart
+++ b/lib/ui/exact_price_view.dart
@@ -7,7 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:google_fonts/google_fonts.dart' hide Config;
 import 'package:shared_preferences/shared_preferences.dart';
-import '../Services/bets_service.dart';
+import '../services/bets_service.dart';
 import '../config/config.dart';
 import '../helpers/common.dart';
 import '../locale/localized_texts.dart';

--- a/lib/ui/first_time_page.dart
+++ b/lib/ui/first_time_page.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:google_fonts/google_fonts.dart';
-import '../Services/bets_service.dart';
+import '../services/bets_service.dart';
 import '../locale/localized_texts.dart';
 import '../helpers/common.dart';
 import 'layout_page.dart';

--- a/lib/ui/markets_page.dart
+++ b/lib/ui/markets_page.dart
@@ -9,7 +9,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tutorial_coach_mark/tutorial_coach_mark.dart';
-import '../Services/bets_service.dart';
+import '../services/bets_service.dart';
 import '../candlesticks/src/models/candle.dart';
 import '../enums/financial_assets.dart';
 import '../helpers/common.dart';

--- a/lib/ui/markets_page.dart
+++ b/lib/ui/markets_page.dart
@@ -1395,7 +1395,9 @@ class _LeafCardWidgetState extends State<_LeafCardWidget> {
   @override
   void initState() {
     super.initState();
-    _currency = widget.dollarCurrency ? '\$' : '€';
+    // Para Forex, no mostrar símbolo de moneda
+    final isForex = Common().isTickerForex(widget.asset.ticker);
+    _currency = isForex ? '' : (widget.dollarCurrency ? '\$' : '€');
     _loadPriceData();
   }
 
@@ -1577,7 +1579,7 @@ class _LeafCardWidgetState extends State<_LeafCardWidget> {
                                       ticker: widget.asset.ticker,
                                       currentValue: candles.first.close,
                                       iconPath: widget.asset.icon,
-                                      isForex: widget.asset.group.toLowerCase() == "forex",
+                                      isForex: Common().isTickerForex(widget.asset.ticker),
                                     ),
                                   ),
                                 );

--- a/lib/ui/store_page.dart
+++ b/lib/ui/store_page.dart
@@ -10,7 +10,7 @@ import 'package:google_fonts/google_fonts.dart' hide Config;
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import '../Services/bets_service.dart';
+import '../services/bets_service.dart';
 import '../config/config.dart';
 import '../helpers/common.dart';
 import '../locale/localized_texts.dart';

--- a/lib/ui/withdraw_page.dart
+++ b/lib/ui/withdraw_page.dart
@@ -7,7 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import '../Services/bets_service.dart';
+import '../services/bets_service.dart';
 import '../helpers/common.dart';
 import '../helpers/slider.dart';
 import '../services/firebase_service.dart';


### PR DESCRIPTION
5d41ce1 - Remove currency symbols for Forex items in markets list and charts
f63183b - Fix: Forzar EUR en fetchCandles para items de tipo Forex


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves forex handling and cleans up imports.
> 
> - Force `EUR` in `BetsService.fetchCandles` when `Common().isTickerForex(symbol)` is true
> - Suppress currency symbols for forex in charts (`PriceColumn`) and markets list (card currency display); propagate `isForex` using `Common().isTickerForex`
> - Normalize imports from `Services/` to `services/` across multiple files
> - Minor cleanup in `Common.isTickerForex` implementation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d41ce12cf1d2403607c35dd2e92e9f19b1459b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->